### PR TITLE
Update Pact version to 3.6.14

### DIFF
--- a/consumer/build.gradle
+++ b/consumer/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "au.com.dius.pact" version "3.5.14"
+  id "au.com.dius.pact" version "3.6.14"
 }
 
 apply plugin: 'application'

--- a/providers/springboot-provider/build.gradle
+++ b/providers/springboot-provider/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-  id "au.com.dius.pact" version "3.5.14"
+  id "au.com.dius.pact" version "3.6.14"
   id "com.wiredforcode.spawn" version "0.8.2"
 }
 


### PR DESCRIPTION
Updating the pact version to the latest 3.x version available.
This will solve build errors on newer Gradle versions, see #17.